### PR TITLE
add secrets to production

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -32,3 +32,5 @@ test:
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  github_client_id: <%= ENV["GITHUB_CLIENT_ID"] %>
+  github_client_secret: <%= ENV["GITHUB_CLIENT_SECRET"] %>


### PR DESCRIPTION
## Problem
Github integration is broken because I forgot to add keys/secrets to prod

## Solution
Add placeholder for keys and add secrets to heroku

## Additional Comments
